### PR TITLE
include link to git repository

### DIFF
--- a/build.pl
+++ b/build.pl
@@ -82,6 +82,12 @@ content can be appended using Excel::Writer::XLSX. ],
    },   
    add_to_cleanup => [qw(Excel-Template-XLSX-* *.zip *.pui *.prj make.bat)],
    create_makefile_pl => 'traditional',
+   meta_merge => {
+       resources => {
+           repository => 'https://github.com/davidsclarke/Excel-Template-XLSX',
+           bugtracker => 'https://github.com/davidsclarke/Excel-Template-XLSX/issues'
+       }
+   },
 
 );
 


### PR DESCRIPTION
upon the next release this will include the links in the META files that are included in the distribution which will enable MetaCPAN to link to the git repository.